### PR TITLE
fix: don't consider double underscore non-objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coconfig",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Centralize your per-package rc, dotfile and config files into one extensible config file",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,10 @@ export default async function runCoConfig(env: CoConfigEnvironment, coconfig: Co
   }
 
   await configs.reduce((promise, [name, entry]) => {
+    if (name.startsWith('__') && typeof entry !== 'object') {
+      // Cruft, like __esmodule
+      return promise;
+    }
     if (typeof entry === 'string') {
       return promise
         .then(() => resolveFilename(name))


### PR DESCRIPTION
Some bundlers add symbols like __esModule, which breaks coconfig.